### PR TITLE
layer hiding

### DIFF
--- a/src/algo/Algorithm.js
+++ b/src/algo/Algorithm.js
@@ -212,12 +212,12 @@ export default class Algorithm {
 		this.commands = [];
 	}
 
-	addCodeToCanvasBase(code, start_x, start_y, isCode, line_height, standard_color, layer) {
+	addCodeToCanvasBase(code, start_x, start_y, line_height, standard_color, layer) {
 		line_height = typeof line_height !== 'undefined' ? line_height : CODE_LINE_HEIGHT;
 		standard_color =
 			typeof standard_color !== 'undefined' ? standard_color : CODE_STANDARD_COLOR;
 		layer = typeof layer !== 'undefined' ? layer : 0;
-		isCode = true;
+		const isCode = true;
 		const codeID = Array(code.length);
 		let i, j;
 		for (i = 0; i < code.length; i++) {

--- a/src/algo/DFS.js
+++ b/src/algo/DFS.js
@@ -186,9 +186,9 @@ export default class DFS extends Graph {
 		];
 
 		if (this.physicalStack) {
-			this.codeID = this.addCodeToCanvasBase(this.itCode, CODE_START_X, CODE_START_Y);
+			this.codeID = this.addCodeToCanvasBase(this.itCode, CODE_START_X, CODE_START_Y, undefined, undefined, 1);
 		} else {
-			this.codeID = this.addCodeToCanvasBase(this.recCode, CODE_START_X, CODE_START_Y);
+			this.codeID = this.addCodeToCanvasBase(this.recCode, CODE_START_X, CODE_START_Y, undefined, undefined, 1);
 		}
 
 		this.animationManager.setAllLayers([0, this.currentLayer]);

--- a/src/algo/Dijkstras.js
+++ b/src/algo/Dijkstras.js
@@ -126,7 +126,7 @@ export default class Dijkstras extends Graph {
 			['    PQ.enqueue((w, d + d2))'],
 		];
 
-		this.codeID = this.addCodeToCanvasBase(this.code, CODE_START_X, CODE_START_Y);
+		this.codeID = this.addCodeToCanvasBase(this.code, CODE_START_X, CODE_START_Y, undefined, undefined, 1);
 
 		this.tableEntryHeight = this.isLarge ? LARGE_TABLE_ENTRY_HEIGHT : SMALL_TABLE_ENTRY_HEIGHT;
 		for (let i = 0; i < this.size; i++) {

--- a/src/algo/Graph.js
+++ b/src/algo/Graph.js
@@ -221,8 +221,8 @@ export default class Graph extends Algorithm {
 		this.animationManager.setAllLayers([0, newLayer]);
 		this.currentLayer = newLayer;
 		if (this.currentLayer !== 1) {
-			console.log(this.codeID);
-			this.hideCodeFromCanvas(this.codeID);
+			//console.log(this.codeID);
+			//this.hideCodeFromCanvas(this.codeID);
 		}
 	}
 

--- a/src/algo/Kruskals.js
+++ b/src/algo/Kruskals.js
@@ -166,7 +166,7 @@ export default class Kruskals extends Graph {
 			[`    merge u's cluster with v's cluster`],
 		];
 
-		this.codeID = this.addCodeToCanvasBase(this.code, CODE_START_X, CODE_START_Y);
+		this.codeID = this.addCodeToCanvasBase(this.code, CODE_START_X, CODE_START_Y, undefined, undefined, 1);
 
 		this.animationManager.setAllLayers([0, this.currentLayer]);
 		this.animationManager.startNewAnimation(this.commands);


### PR DESCRIPTION
For the problematic algorithms, the pseudocode is rendered on layer 1. That way it only shows up when layer 1 (the logical representation) is selected. BFS and Prim's seem to have enough space since the code is on the left side so I didn't touch those